### PR TITLE
Create zh_CN.lang

### DIFF
--- a/lang/zh_CN.lang
+++ b/lang/zh_CN.lang
@@ -1,0 +1,49 @@
+# Cyan Warrior Swords Mod Language File = Mainland Chinese
+# Thanks to micdoodle!
+
+# SWORDS
+item.fireSword.name=烈焰之刃
+item.darkSword.name=黑暗之刃
+item.earthSword.name=大地之刃
+item.enderSword.name=末影之刃
+item.lightSword.name=光明之刃
+item.meteorSword.name=流星之刃
+item.peacefulNatureSword.name=自然之刃
+item.thunderSword.name=闪雷之刃
+item.waterSword.name=奔流之刃
+item.wildNatureSword.name=疾风自然之刃
+item.windSword.name=疾风之刃
+item.thunderstormSword.name=雷暴之刃
+item.iceSword.name=寒冰之刃
+item.meteoricthunderstormSword.name=流星雷暴之刃
+item.enderFireSword.name=末影烈焰之刃
+item.enderThunderSword.name=末影闪雷之刃
+item.enderWindSword.name=末影疾风之刃
+item.thunderShockSword.name=雷鸣之刃
+item.timeSword.name=时光之刃
+item.beastSword.name=猛兽之牙
+item.windBlastSword.name=爆裂剑
+item.darkNetherSword.name=黑暗地狱之刃
+item.lightNetherSword.name=光明地狱之刃
+item.enderPortalSword.name=末影传送之刃
+item.trienderSword.name=终极末影之刃
+item.SteamSword.name=蒸汽之刃
+item.BlizzardSword.name=暴雪之刃
+item.WindWhirlSword.name=旋风之刃
+item.CyanSword.name=战神之刃
+
+# Essences
+
+item.EssenceFire.name=火之精华 
+item.EssenceBeast.name=猛兽精华 
+item.EssenceDark.name=暗之精华 
+item.EssenceEarth.name=地之精华 
+item.EssenceEnder.name=末影精华 
+item.EssenceLight.name=光之精华 
+item.EssenceThunder.name=雷之精华 
+item.EssenceWater.name=水之精华 
+item.EssenceWind.name=风之精华
+item.EssenceMixed.name=混合精华
+item.SwordHandle.name=基础剑柄
+
+# </file>


### PR DESCRIPTION
Hi, my name is Joccob, I really love your CWS (Cyan Warrior Sword) mod. There are so many cool sword in this mod !

I try to translate the en_US.lang file to Chinese. It works fine with all the essence, but the swords' name remain the same. The same problem happens to German lang file as well. Thus I think the lang file maybe outdated...I would be really thankful if you can fix it.

And I wonder if I can reprint this mod on MCBBS which is one of the most famous Chinese minecraft forum. I will introduce this mod to more Chinese so that they can enjoy your mod as well. I will NOT take any credits of the mod and all the link will direct to your official website (Curseforge and Minecraftforum). I do need your permission to do this, so are you ok with that?
